### PR TITLE
Feat: Add tests for `list-a` command

### DIFF
--- a/src/main/java/seedu/address/model/assignment/AssignmentNameContainsKeywordsPredicate.java
+++ b/src/main/java/seedu/address/model/assignment/AssignmentNameContainsKeywordsPredicate.java
@@ -1,0 +1,46 @@
+package seedu.address.model.assignment;
+
+import java.util.List;
+import java.util.function.Predicate;
+
+import seedu.address.commons.util.StringUtil;
+import seedu.address.commons.util.ToStringBuilder;
+
+
+/**
+ * Tests that a {@code Assignment}'s {@code Name} matches any of the keywords given.
+ */
+public class AssignmentNameContainsKeywordsPredicate implements Predicate<Assignment> {
+    private final List<String> keywords;
+
+    public AssignmentNameContainsKeywordsPredicate(List<String> keywords) {
+        this.keywords = keywords;
+    }
+
+    @Override
+    public boolean test(Assignment assignment) {
+        return keywords.stream()
+                .anyMatch(keyword -> StringUtil.containsWordIgnoreCase(assignment.getName().taskName, keyword));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof AssignmentNameContainsKeywordsPredicate)) {
+            return false;
+        }
+
+        AssignmentNameContainsKeywordsPredicate otherAssignmentNameContainsKeywordsPredicate =
+                (AssignmentNameContainsKeywordsPredicate) other;
+        return keywords.equals(otherAssignmentNameContainsKeywordsPredicate.keywords);
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this).add("keywords", keywords).toString();
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/CommandAssignmentTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandAssignmentTestUtil.java
@@ -27,7 +27,7 @@ import seedu.address.model.assignment.IsoDate;
  */
 public class CommandAssignmentTestUtil {
 
-    public static final String VALID_NAME_ASSIGNMENT = "CS2100 Assignment 2";
+    public static final String VALID_NAME_ASSIGNMENT = "CS2105 Assignment 2";
     public static final String VALID_NAME_PROJECT = "CS2103T Quiz";
     public static final String VALID_DESCRIPTION_ASSIGNMENT = "Assignment until K-maps";
     public static final String VALID_DESCRIPTION_PROJECT = "Lecture Quiz";

--- a/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
+++ b/src/test/java/seedu/address/logic/commands/CommandTestUtil.java
@@ -18,6 +18,8 @@ import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.logic.commands.person.EditCommand;
 import seedu.address.model.AddressBook;
 import seedu.address.model.Model;
+import seedu.address.model.assignment.Assignment;
+import seedu.address.model.assignment.AssignmentNameContainsKeywordsPredicate;
 import seedu.address.model.person.NameContainsKeywordsPredicate;
 import seedu.address.model.person.Person;
 import seedu.address.testutil.EditPersonDescriptorBuilder;
@@ -76,7 +78,7 @@ public class CommandTestUtil {
      * - the {@code actualModel} matches {@code expectedModel}
      */
     public static void assertCommandSuccess(Command command, Model actualModel, CommandResult expectedCommandResult,
-            Model expectedModel) {
+                                            Model expectedModel) {
         try {
             CommandResult result = command.execute(actualModel);
             assertEquals(expectedCommandResult, result);
@@ -91,7 +93,7 @@ public class CommandTestUtil {
      * that takes a string {@code expectedMessage}.
      */
     public static void assertCommandSuccess(Command command, Model actualModel, String expectedMessage,
-            Model expectedModel) {
+                                            Model expectedModel) {
         CommandResult expectedCommandResult = new CommandResult(expectedMessage);
         assertCommandSuccess(command, actualModel, expectedCommandResult, expectedModel);
     }
@@ -112,6 +114,7 @@ public class CommandTestUtil {
         assertEquals(expectedAddressBook, actualModel.getAddressBook());
         assertEquals(expectedFilteredList, actualModel.getFilteredPersonList());
     }
+
     /**
      * Updates {@code model}'s filtered list to show only the person at the given {@code targetIndex} in the
      * {@code model}'s address book.
@@ -126,4 +129,19 @@ public class CommandTestUtil {
         assertEquals(1, model.getFilteredPersonList().size());
     }
 
+    /**
+     * Updates {@code model}'s filtered list to show only the assignment at the given {@code targetIndex} in the
+     * {@code model}'s address book.
+     */
+    public static void showAssignmentAtIndex(Model model, Index targetIndex) {
+        assertTrue(targetIndex.getZeroBased() < model.getFilteredAssignmentList().size());
+
+        Assignment assignment = model.getFilteredAssignmentList().get(targetIndex.getZeroBased());
+        final String[] splitName = assignment.getName().taskName.split("\\s+");
+        model.updateFilteredAssignmentList(
+                new AssignmentNameContainsKeywordsPredicate(
+                        Arrays.asList(splitName[0])));
+
+        assertEquals(1, model.getFilteredAssignmentList().size());
+    }
 }

--- a/src/test/java/seedu/address/logic/commands/assignment/ListAssignmentCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/assignment/ListAssignmentCommandTest.java
@@ -1,0 +1,40 @@
+package seedu.address.logic.commands.assignment;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showAssignmentAtIndex;
+import static seedu.address.testutil.TypicalAssignments.getTypicalAddressBook;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_ASSIGNMENT;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+
+
+/**
+ * Contains integration tests (interaction with the Model) and unit tests for ListCommand.
+ */
+public class ListAssignmentCommandTest {
+
+    private Model model;
+    private Model expectedModel;
+
+    @BeforeEach
+    public void setUp() {
+        model = new ModelManager(getTypicalAddressBook(), new UserPrefs());
+        expectedModel = new ModelManager(model.getAddressBook(), new UserPrefs());
+    }
+
+    @Test
+    public void execute_listIsNotFiltered_showsSameList() {
+        assertCommandSuccess(new ListAssignmentCommand(), model, ListAssignmentCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+
+    @Test
+    public void execute_listIsFiltered_showsEverything() {
+        showAssignmentAtIndex(model, INDEX_FIRST_ASSIGNMENT);
+        assertCommandSuccess(new ListAssignmentCommand(), model, ListAssignmentCommand.MESSAGE_SUCCESS, expectedModel);
+    }
+}


### PR DESCRIPTION
Chore: Update TypicalAssignments to change CS2100 Assignment 2 to CS2105 Assignment 2 because of the way showAssignmentAtIndex works. It only checks for the first word in the assignment name, and checks the size of the returned filtered assignment list, so it breaks if I had 2 CS2100 test assignments.